### PR TITLE
Changed font sizes to match Modelica 2017 template

### DIFF
--- a/LaTeX/example-paper.tex
+++ b/LaTeX/example-paper.tex
@@ -1,4 +1,4 @@
-%% sample file for Modelica 2015 Conference paper
+%% sample file for Modelica 2017 Conference paper
 %% Copyright 2015 DLR and the Modelica Association
 %
 % This work may be distributed and/or modified under the
@@ -12,13 +12,14 @@
 % This work is 'maintained' on GitHub:
 %   https://github.com/modelica-association/conference-templates
 %
-% The Current Maintainers are: @akloeckner, @dietmarw, @berhnard-thiele
+% The Current Maintainers are: @akloeckner, @dietmarw, @bernhard-thiele
+% With additions by @casella
 %
 % This work consists of all files in the GitHub repository except
 % a) The files indicated by .gitignore files
 % b) The GitHub management files .gitignore, *.md
 %
-% This class is created from the template for the Modelica 2015 conference
+% This class is created from the template for the Modelica 2017 conference
 
 %%% By default the modelica LaTeX class uses bibtex and natbib for refrences
 \documentclass{modelica}
@@ -31,7 +32,7 @@
 \hypersetup{%
 	pdftitle  = {Latex Template for the International Modelica Conference},
 	pdfauthor = {Author Name1, Author Name2},
-        pdfsubject = {11th International Modelica Conference 2015},
+        pdfsubject = {12th International Modelica Conference 2017},
         pdfkeywords = {Modelica, confercence, LaTeX, template},
 	hidelinks,
 	pdfpagelayout = SinglePage,
@@ -42,14 +43,14 @@
 \begin{document}
 \thispagestyle{empty}
 
-\title{Int. Modelica Conf. 2015 Paper Title}
+\title{Int. Modelica Conf. 2017 Paper Title}
 \author[1]{Author Name}
 \author[1]{Author Name}
 \author[2]{Author Name}
 \affil[1]{Department, University, Country, {\small\texttt{\{name1,name2\}@university.org}}}
 \affil[2]{Company, Country, {\small\texttt{name3@company}}}
 
-% \title{\textbf{Int. Modelica Conf. 2015 Paper Title}}
+% \title{\textbf{Int. Modelica Conf. 2017 Paper Title}}
 % \author{{\large
 % Author Name$^1$ \quad Author Name$^1$ \quad Author Name$^2$\vspace{2mm}\\
 %   {}$^1$Department, University, Country, \textsf{\{name1,name2\}@university.org}\\
@@ -155,6 +156,31 @@ Equations should be numbered on the right side, such as:
 a_1& =b_1+c_1\\
 a_2& =b_2+c_2-d_2+e_2
 \end{align}
+
+\section{Additional meaningless text}
+This section contains additional text to bring the example length to three pages
+
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque faucibus, arcu non malesuada condimentum, nibh est aliquet nunc, in tempus nisi urna id dolor. Suspendisse potenti. Sed nec accumsan massa, porttitor placerat purus. Mauris nibh tellus, lobortis ac posuere non, bibendum ut mi. Etiam et quam at arcu gravida ullamcorper. Donec eget tortor eros. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec quis odio tellus. Integer consequat vulputate dolor, sit amet sodales nibh dapibus eu. Quisque accumsan mauris tellus, ut sollicitudin sapien finibus in. Fusce congue, mauris vestibulum vulputate commodo, quam leo faucibus purus, id luctus augue est vitae dolor. Suspendisse id ultrices diam, eget viverra diam. Donec non sem mauris. Fusce sagittis neque justo, in mollis felis luctus in. Pellentesque tincidunt mauris a feugiat accumsan. Nulla eget sem nisi.
+
+Cras enim tortor, luctus et vulputate vitae, condimentum quis massa. Nullam fermentum, lectus a mattis laoreet, eros nunc interdum nibh, in commodo justo ipsum quis mauris. Donec imperdiet faucibus lacinia. Phasellus malesuada porta arcu, nec molestie dui posuere quis. Donec porttitor, tellus id egestas feugiat, dui quam luctus dui, vel ornare metus lorem sit amet ex. Sed bibendum convallis condimentum. Vivamus eu consectetur felis. Sed turpis nisi, malesuada id augue eu, semper pulvinar metus. Nullam id ante sed mauris bibendum iaculis. Proin rhoncus justo mauris, vel iaculis nunc rhoncus in. Aenean nec lectus non eros mollis lacinia. Fusce at massa in nunc scelerisque egestas. Nulla in turpis ante. Quisque luctus at velit vitae iaculis.
+
+Etiam nec sapien risus. Duis lorem felis, varius et purus at, malesuada pellentesque enim. Fusce lobortis ac elit eget feugiat. Nam purus libero, aliquam eu urna quis, volutpat eleifend leo. Ut a volutpat felis. Praesent lobortis sapien nunc, vel mattis nisi laoreet et. Praesent elementum ex a fringilla pulvinar. Vestibulum condimentum elementum pharetra. Mauris condimentum tempus risus, tincidunt viverra velit. Proin dictum ligula lectus, vitae euismod ligula rutrum non. Nunc non enim ultrices, sollicitudin nibh ut, lacinia ex. Nullam ac ullamcorper ante. Nullam tristique laoreet enim, sit amet suscipit risus imperdiet non. Vivamus id turpis egestas, viverra mauris non, sagittis purus.
+
+Phasellus eget lobortis magna. Mauris faucibus elit eget magna gravida, nec ultrices eros consectetur. Quisque porttitor tincidunt nunc vitae gravida. Vestibulum laoreet tempus feugiat. Etiam sit amet molestie urna. Praesent libero nisi, sollicitudin accumsan ullamcorper auctor, mollis sed nulla. Pellentesque consequat, nibh ac ultrices pulvinar, tortor enim aliquet augue, non facilisis lorem arcu nec justo. Vestibulum posuere a metus nec aliquam. Quisque commodo, neque rhoncus scelerisque viverra, velit sapien mollis tellus, et scelerisque est massa vitae risus. Cras sollicitudin nisl sit amet suscipit lobortis. Vivamus sit amet arcu rhoncus, varius nisi id, viverra leo. In hac habitasse platea dictumst. Pellentesque placerat sem rutrum condimentum elementum. Cras euismod augue et luctus facilisis.
+
+Phasellus feugiat vehicula dolor, eu dapibus ex aliquam vitae. Nunc tortor magna, lacinia id consectetur et, lacinia id enim. Nunc at consectetur odio, ac blandit ex. Aliquam pharetra mi vitae mauris maximus, in sagittis orci ultrices. Curabitur sagittis tortor sem, ornare aliquet dolor congue vitae. Etiam sed nunc ut leo gravida commodo. Maecenas rhoncus odio id tortor blandit dignissim. Proin sed tincidunt metus, eget pharetra odio. Nullam et imperdiet nisl. Praesent sagittis, nunc vel laoreet tristique, quam lorem varius quam, ut varius est purus sit amet tellus. Cras ac massa neque. Aliquam pulvinar auctor elit in tincidunt.
+
+Maecenas iaculis odio at purus porta, ac tincidunt libero interdum. Aliquam sed sapien leo. Duis malesuada pharetra ex, eu vulputate est mattis at. Cras et lacus ac quam pellentesque efficitur et ut purus. Sed sed eros non justo gravida volutpat sed non libero. Proin imperdiet pretium mattis. Quisque sapien ex, dignissim vitae eleifend id, hendrerit at neque. Sed ultrices ante purus, nec hendrerit urna congue sed. Maecenas malesuada bibendum velit, convallis varius sapien volutpat vel. Ut malesuada pretium orci, eu elementum leo malesuada id. Etiam ullamcorper lobortis imperdiet. Phasellus ornare bibendum ante vitae vestibulum. Integer eu arcu sit amet ligula elementum blandit.
+
+Praesent suscipit, purus eget tempor placerat, lectus lorem facilisis odio, at sagittis sapien leo ac justo. Etiam suscipit quis nisl vel posuere. Suspendisse vulputate arcu eu metus maximus, vitae scelerisque elit porta. Aliquam pulvinar libero in libero interdum iaculis. In metus ligula, vestibulum et ligula eu, sagittis mattis odio. Duis in convallis lorem. Nam at pharetra est. Donec eleifend fringilla odio vitae placerat. Integer sit amet eros eget odio condimentum placerat sit amet sed purus. Nulla at ultrices velit. Etiam ornare, purus non lacinia ullamcorper, nunc augue interdum magna, quis laoreet ante risus id sapien.
+
+Aenean id leo gravida, sodales sem ut, imperdiet mauris. Proin pellentesque libero laoreet libero volutpat, quis euismod nibh commodo. Nam et dui vel augue convallis aliquam. Mauris magna diam, ultricies eget placerat porttitor, hendrerit non mi. Quisque pulvinar varius ex, sollicitudin vestibulum est cursus eu. Sed lobortis volutpat massa sed bibendum. Cras rutrum, sem sit amet iaculis egestas, nisi turpis vehicula ipsum, eget congue risus enim vehicula turpis. Curabitur sit amet tortor vitae augue tempor consequat.
+
+Vestibulum volutpat luctus arcu non elementum. Donec sed lectus id sapien varius laoreet sit amet non nulla. Morbi iaculis turpis tincidunt consectetur feugiat. Donec orci dolor, sagittis in mi ut, gravida iaculis ante. Quisque ut risus a leo laoreet aliquam nec non nulla. Vestibulum ut ipsum vehicula, tempor tortor at, faucibus ipsum. Aliquam varius enim id lacus sagittis, lacinia pretium ipsum aliquam. Ut nulla velit, faucibus eget leo a, sollicitudin vehicula ante. Donec leo ex, fermentum vel imperdiet in, venenatis commodo odio. Donec lacinia bibendum erat ac venenatis.
+
+Nunc volutpat viverra turpis, sit amet porta nunc viverra vitae. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nullam ut gravida ex, non tincidunt sem. Fusce ac mollis lacus. Duis ac arcu pretium, maximus sapien sed, tristique nulla. Fusce suscipit feugiat ornare. Curabitur vitae accumsan mauris, non suscipit metus. Sed venenatis, lectus sit amet porta blandit, velit arcu rhoncus leo, a laoreet justo urna quis tortor. Nullam faucibus nibh sed ornare sodales. Nulla tempus velit neque, quis elementum dui accumsan ac. Cras fermentum maximus ipsum sit amet volutpat. Mauris consequat leo non finibus tristique. Sed pulvinar risus varius aliquet imperdiet. Vivamus egestas quis tellus vitae aliquet.
 
 \section{Bibliographic References}
 The bibliographic reference list are shown at the end of the paper;

--- a/LaTeX/example-paper.tex
+++ b/LaTeX/example-paper.tex
@@ -1,5 +1,5 @@
 %% sample file for Modelica 2017 Conference paper
-%% Copyright 2015 DLR and the Modelica Association
+%% Copyright  Modelica Association
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License, either version 1.3

--- a/LaTeX/modelica.cls
+++ b/LaTeX/modelica.cls
@@ -51,9 +51,9 @@
 \pagestyle{empty}                %% no page numbers!
 
 % Some sizes
-\renewcommand{\normalsize}  {\fontsize{10.95pt}{12.3pt}\selectfont}
-\renewcommand{\small}       {\fontsize{09.00pt}{11.1pt}\selectfont}
-\renewcommand{\footnotesize}{\fontsize{08.00pt}{09.9pt}\selectfont}
+\renewcommand{\normalsize}  {\fontsize{10.5pt}{12.3pt}\selectfont}
+\renewcommand{\small}       {\fontsize{09.5pt}{11.1pt}\selectfont}
+\renewcommand{\footnotesize}{\fontsize{08.5pt}{09.9pt}\selectfont}
 
 % Labels and captions
 \RequirePackage[labelfont=bf, labelsep=period, font=small]{caption}  %% Get bold Figure/Table caption

--- a/LaTeX/modelica.cls
+++ b/LaTeX/modelica.cls
@@ -70,9 +70,9 @@
 % Redefine \author's \and
 \def\and{\quad}
 
-% Redefine \title to be \textbf
+% Redefine \title to be \textbf and move it up to a height similar to the Word template
 \let\modelica@title\title
-\renewcommand{\title}[1]{\modelica@title{\textbf{#1}}}
+\renewcommand{\title}[1]{\modelica@title{\vspace{-1.0cm}\textbf{#1}}}
 
 % Redefine \date for it not to be used
 \date{} % <--- leave date empty


### PR DESCRIPTION
@casella based the current Modelica 2017 template on the last Modelica Conf., instead on the template within this repo. No I noticed that different font sizes are used in

- the last Modelica Conf. template
- the current repo template
- the latest Modelica 2017 template

@akloeckner what was the reason that you took the font sizes in the repo? Anything that speaks against updating to the font sizes used by @casella?