### PR TITLE
Update Modelica listings from MLS

### DIFF
--- a/LaTeX/resources/listings-modelica.cfg
+++ b/LaTeX/resources/listings-modelica.cfg
@@ -17,37 +17,64 @@
 %
 % This work consists of the file listings-modelica.cfg
 
-\lstdefinelanguage{modelica}
-{
-  morekeywords=[1]{
-    algorithm,and,annotation,as,assert,block,break,case,class,connect,connector,
-    constant,constrainedby,der,discrete,each,else,elseif,elsewhen,encapsulated,
-    end,enumeration,equality,equation,expandable,extends,external,failure,final,
-    flow,for,function,guard,if,import,in,initial,inner,input,List,local,loop,
-    match,matchcontinue,model,not,operator,Option,or,outer,output,package,parameter,
-    partial,protected,public,record,redeclare,replaceable,return,stream,
-    subtypeof,then,Tuple,type,uniontype,when,while},
-  morekeywords=[2]{true, false},
-  % Do not make true,false keywords because fn(true,x, false ) shows up as fn(true,x, *false*)
-  sensitive=true,
-  comment=[l]//,
-  morecomment=[s]{/*}{*/},
-  alsodigit={.,-},
-  morestring=[b]',
-  morestring=[b]",
+\lstdefinelanguage{modelica}{% Language for use with the lstlisting environment.
+%   otherkeywords={-, =, +, [, ], (, ), \{, \}, :, *, !},%
+    morekeywords=[1]{% Keywords not used to define code structure
+        der,connect,assert,terminate,break,return,%
+        false,true,and,not,or,%
+        final,each,%
+        flow,stream,%
+        input,output,%
+        discrete,parameter,constant,%
+    },
+    morekeywords=[2]{% Keywords used to define code structure
+        annotation,block,class,connector,constrainedby,%
+        encapsulated,enumeration,else,elseif,elsewhen,end,%
+        expandable,extends,external,for,%
+        function,if,in,inner,initial,import,loop,model,operator,outer,%
+        package,partial,record,redeclare,replaceable,%
+        then,type,when,while,within,algorithm,equation,%
+        protected,public,pure,impure,%
+    },%
+    % Note: initial is in both variants - depending on context, use first variant
+    morekeywords=[3]{% Selected recognized names that are not actual keywords, including:
+        % 3.7.2 #derivative-and-special-purpose-operators-with-function-syntax
+        delay,cardinality,homotopy,semiLinear,inStream,actualStream,spatialDistribution,getInstanceName,%
+        terminal,noEvent,smooth,sample,pre,edge,change,reinit,%
+        % 3.7.3 #event-related-operators-with-function-syntax (except initial)
+        previous,hold,subSample,superSample,shiftSample,backSample,noClock,firstTick,interval,%
+        % 4.8 #predefined-types-and-classes
+        Real,Integer,Boolean,String,%
+        % Highlights from #built-in-array-functions
+        promote,ndims,size,%
+        % Assorted things from #state-machines -- what about all the other operators in this chapter?
+        transition,initialState,%
+    },%
+    sensitive=true, % just in case
+    comment=[l]{//}, % comment lines
+    morecomment=[s]{/*}{*/}, % comment blocs
+    morestring=[b]{'},
+    morestring=[b]{"},
 }[keywords,comments,strings]
 
-\definecolor{keywordcolor1}{rgb}{0,0,.4}
+\definecolor{keywordcolor1}{rgb}{0.00, 0.20, 0.47}
 \definecolor{keywordcolor2}{rgb}{.90,0,0}
+\definecolor{keywordcolor3}{rgb}{0.33, 0.24, 0.03}
+\definecolor{commentcolor}{rgb}{0.07, 0.46, 0.00}
 \definecolor{stringcolor}{rgb}{0.133,0.545,0.133}
-% \definecolor{listingbgcolor}{rgb}{0.95,0.95,0.95}
+% \definecolor{commentcolor}{rgb}{0.00, 0.50, 0.00}
+% \definecolor{stringcolor}{rgb}{0.50,0.00,0.00}
+\definecolor{listingbgcolor}{rgb}{0.95,0.95,0.95}
 
 \lstset{
   breaklines=true,
   language=modelica,
   basicstyle=\ttfamily,
-  keywordstyle=[1]\color{keywordcolor1}\bfseries,
-  keywordstyle=[2]\color{keywordcolor2},
+  commentstyle=\color{commentcolor}\sffamily, % comment style
+  keywordstyle=\color{red},        % Unused keyword style in bright red to make it easy to detect and fix.
+  keywordstyle=[1]\color{keywordcolor1},
+  keywordstyle=[2]\color{keywordcolor1}\bfseries,
+  keywordstyle=[3]\color{keywordcolor3},
   stringstyle=\color{stringcolor},
 %  backgroundcolor=\color{listingbgcolor},
   framexleftmargin=5pt,


### PR DESCRIPTION
This updates the Modelica listings according to the latest layout changes within MAP-LANG for the Modelica Language Specification v3.6-dev by @henrikt-ma: https://github.com/modelica/ModelicaSpecification/blob/master/mlsshared.sty

Should this also go to https://github.com/modelica-tools/listings-modelica?